### PR TITLE
feat(ytdl-mpv): s/youtube-dl/yt-dlp/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="https://github.com/andros21/ytdl-mpv/blob/master/LICENSE">
     <img src="https://img.shields.io/github/license/andros21/ytdl-mpv?color=blue&label=License&style=flat-square" alt="License">
   </a>
-  <h4 align="center">Rofi script to browse and play YouTube contents <br>using <a href="https://github.com/ytdl-org/youtube-dl/">youtube-dl</a> and <a href="https://github.com/mpv-player/mpv">mpv</a></h4>
+  <h4 align="center">Rofi script to browse and play YouTube contents <br>using <a href="https://github.com/yt-dlp/yt-dlp/">yt-dlp</a> and <a href="https://github.com/mpv-player/mpv">mpv</a></h4>
   <div align="center">
     <a href="#star-features">Features</a>
     ·
@@ -49,7 +49,7 @@
 * `nc` `sqlite3` `xargs`
 * [`mpv`](https://github.com/mpv-player/mpv)
 * [`rofi>=1.6.1`](https://github.com/davatorium/rofi)
-* [`youtube-dl==latest`](https://github.com/ytdl-org/youtube-dl)
+* [`yt-dlp==latest`](https://github.com/yt-dlp/yt-dlp)
 
 **Opt dependencies**
 

--- a/bin/mpvctl
+++ b/bin/mpvctl
@@ -25,7 +25,7 @@ _die() {
 # Ensure dependencies
 _checkDep() {
    type mpv > /dev/null 2>&1 || _die "Cannot find mpv in your \$PATH"
-   type youtube-dl > /dev/null 2>&1 || _die "Cannot find youtube-dl in your \$PATH"
+   type yt-dlp > /dev/null 2>&1 || _die "Cannot find yt-dlp in your \$PATH"
    type nc > /dev/null 2>&1 && SOCKCMD="nc -U -N $SOCKET"
    type socat > /dev/null 2>&1 && SOCKCMD="socat - $SOCKET"
    [ "$SOCKCMD" ] || _die "Cannot find socat or nc in your \$PATH. Install before continue"
@@ -123,7 +123,7 @@ _getPlaylist() {
                "select distinct title from main where id='${trid}'" 2> /dev/null)"
             if [ -z "$trtitle" ]; then
                local trtitle
-               trtitle=$(youtube-dl --get-filename "$trid" -o "%(title)s" 2> /dev/null)
+               trtitle=$(yt-dlp --get-filename "$trid" -o "%(title)s" 2> /dev/null)
                # cache this single search as relative to a NULL query
                sqlite3 "${db}" \
                   "insert into main (query,id,title) values ('NULL','${trid}','${trtitle}')" \
@@ -132,10 +132,10 @@ _getPlaylist() {
          else
             # searching track title, using ytdl
             local trtitle
-            trtitle=$(youtube-dl --get-filename "$trid" -o "%(title)s" 2> /dev/null)
+            trtitle=$(yt-dlp --get-filename "$trid" -o "%(title)s" 2> /dev/null)
          fi
          if [ -z "$trtitle" ]; then
-            printf "[Warning] youtube-dl title search fail\n" >&2
+            printf "[Warning] yt-dlp title search fail\n" >&2
             local trtitle
             trtitle="NULL"
          fi

--- a/bin/ytdl-mpv
+++ b/bin/ytdl-mpv
@@ -4,7 +4,7 @@
 # | YTDL-MPV                                   |
 # |                                            |
 # | Browse and play YouTube contents from rofi |
-# | using youtube-dl and mpv                   |
+# | using yt-dlp and mpv                   |
 # |                                            |
 # | Authors: Andrea Rossoni                    |
 # | License: GPLv3                             |
@@ -123,7 +123,7 @@ _info() {
 # Ensure dependencies
 _checkDep() {
    local deps
-   deps=(mpv mpvctl nc rofi sqlite3 youtube-dl xargs xclip)
+   deps=(mpv mpvctl nc rofi sqlite3 yt-dlp xargs xclip)
    for dep in "${deps[@]}"; do
       type "$dep" > /dev/null 2>&1 || {
          if [ "$dep" == "xclip" ]; then
@@ -435,7 +435,7 @@ _searchMenu() {
 
 # Start ytdl search using keywords, and then start/append to playback
 _startPlay() {
-   # youtube-dl search
+   # yt-dlp search
    local query
    query="$(_hashStr "${search}:${NUMBER}")"
    mkdir -p "$CACHEDIR"
@@ -445,11 +445,11 @@ _startPlay() {
    cache="$(_isCachedQuery "$query")"
    if [ -z "$cache" ] || [ "$to_recache" -eq 1 ]; then
       if [ "$to_recache" -eq 1 ]; then _deleteQuery "$query"; fi
-      youtube-dl --default-search \
+      yt-dlp --default-search \
          ytsearch"$NUMBER" "$search" --get-id --get-title \
          2> /dev/null > "$CACHEDIR/$query" &
-      wait "$!"; youtube_dl_exit="$?"
-      [[ "$youtube_dl_exit" -eq 0 ]] || _die "youtube-dl search fail, exit code ${youtube_dl_exit}"
+      wait "$!"; yt_dlp_exit="$?"
+      [[ "$yt_dlp_exit" -eq 0 ]] || _die "yt-dlp search fail, exit code ${yt_dlp_exit}"
       _cacheQuery "$query" 2> /dev/null
       rm -f "$CACHEDIR/$query"
    fi


### PR DESCRIPTION
Nothing against `youtube-dl`, a beautiful project ⭐ , but today was visible how [`yt-dlp`](https://github.com/yt-dlp/yt-dlp) a fork better mantained with some additional features, can react more rapidly to issues

This was the error today when trying to start a youtube stream, here from `mpv` that use a system-wide old `yt-dlp`
```console
$ mpv ytdl://jGDXjY8ARLY
[ytdl_hook] ERROR: [youtube] jGDXjY8ARLY: Unable to extract uploader id; please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
[ytdl_hook] youtube-dl failed: unexpected error occurred
No protocol handler found to open URL ytdl://jGDXjY8ARLY
The protocol is either unsupported, or was disabled at compile-time.
[ytdl_hook] ERROR: [youtube] jGDXjY8ARLY: Unable to extract uploader id; please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
[ytdl_hook] youtube-dl failed: unexpected error occurred
```
This error was reported to both projects yesterday [`yt-dlp`](https://github.com/yt-dlp/yt-dlp/issues/6247) or [`youtube-dl`](https://github.com/ytdl-org/youtube-dl/issues/31530)

This afternoon `yt-dlp` release a version patch [2023.02.17](https://github.com/yt-dlp/yt-dlp/releases/tag/2023.02.17), `youtube-dl` not yet 😞

**No additional feature will be used for now** from `yt-dlp`, only a bin swap, if you prefer to remain to `youtube-dl` free to use an alias. I prefer to not use `youtube-dl` as fallback in dependecies checks cause probably in future I will explore 👀  `yt-dlp` additional feats, and probably use some of them

This PR will remain open for a few more days, so I can test if all is compatible and works fine without deprecation msgs or warnings