### PR TITLE
fix(bin/mpvctl)!: remove potentially faulty `nc`, use `socat`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install deps
         run: |
           sudo apt update
-          sudo apt install mpv rofi
+          sudo apt install socat mpv rofi
           python -m pip install yt-dlp
       - name: Setup some envs
         run: |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 **Dependencies**
 
-* `nc` `sqlite3` `xargs`
+* `socat` `sqlite3` `xargs`
 * [`mpv`](https://github.com/mpv-player/mpv)
 * [`rofi>=1.6.1`](https://github.com/davatorium/rofi)
 * [`yt-dlp==2023.02.17`](https://github.com/yt-dlp/yt-dlp)

--- a/bin/mpvctl
+++ b/bin/mpvctl
@@ -26,9 +26,8 @@ _die() {
 _checkDep() {
     type mpv > /dev/null 2>&1 || _die "Cannot find mpv in your \$PATH"
     type yt-dlp > /dev/null 2>&1 || _die "Cannot find yt-dlp in your \$PATH"
-    type nc > /dev/null 2>&1 && SOCKCMD="nc -U -N $SOCKET"
-    type socat > /dev/null 2>&1 && SOCKCMD="socat - $SOCKET"
-    [ "$SOCKCMD" ] || _die "Cannot find socat or nc in your \$PATH. Install before continue"
+    type socat > /dev/null 2>&1 || _die "Cannot find socat in your \$PATH"
+    SOCKCMD="socat - $SOCKET"
 }
 
 # Check if sock is idle, otherwise exit
@@ -71,7 +70,7 @@ EOF
 
 # Check sock status, only for information
 _getSock() {
-    if [ ! -S $SOCKET  ]; then
+    if [ ! -S "$SOCKET"  ]; then
         printf 'disabled\n'
         exit 0
     fi

--- a/bin/ytdl-mpv
+++ b/bin/ytdl-mpv
@@ -125,7 +125,7 @@ _info() {
 # Ensure dependencies
 _checkDep() {
     local deps
-    deps=(mpv mpvctl nc rofi sqlite3 yt-dlp xargs xclip)
+    deps=(mpv mpvctl socat rofi sqlite3 yt-dlp xargs xclip)
     for dep in "${deps[@]}"; do
         type "$dep" > /dev/null 2>&1 || {
             if [ "$dep" == "xclip" ]; then


### PR DESCRIPTION
there are a plenty of `nc` flavours out there,
and not all support `-U` flag to communicate with unix-socks

BREAKING CHANGE: `socat` required dependency